### PR TITLE
improve Makefile with adaptive and overridable variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,22 @@
 GTK_PIDGIN_INCLUDES= `pkg-config --cflags gtk+-2.0 pidgin`
 
-CFLAGS= -O2 -Wall -fpic -g
-LDFLAGS= -shared
+CC ?= gcc
+CFLAGS += -O2 -Wall -fpic
+LDFLAGS += -shared
+DESTDIR =
+PLUGINDIR = ~/.purple/plugins/
 
 INCLUDES = \
       $(GTK_PIDGIN_INCLUDES)
 
 xmpp-receipts.so: xmpp-receipts.c
-	gcc xmpp-receipts.c $(CFLAGS) $(INCLUDES) $(LDFLAGS) -o xmpp-receipts.so
+	$(CC) xmpp-receipts.c $(CFLAGS) $(INCLUDES) $(LDFLAGS) -o xmpp-receipts.so
 
 install: xmpp-receipts.so
-	mkdir -p ~/.purple/plugins
-	cp xmpp-receipts.so ~/.purple/plugins/
+	install -Dm755 xmpp-receipts.so -t $(DESTDIR)$(PLUGINDIR)
 
 uninstall:
-	rm -f ~/.purple/plugins/xmpp-receipts.so
+	rm -f $(DESTDIR)$(PLUGINDIR)/xmpp-receipts.so
 
 clean:
 	rm -f xmpp-receipts.so


### PR DESCRIPTION
this makes it easier for packagers to override certain variables or just adaptively add some additions to CFLAGS and LDFLAGS if those are defined externally
